### PR TITLE
Show item instead of value for Scroll Picker

### DIFF
--- a/lib/pickers/scroll_picker.dart
+++ b/lib/pickers/scroll_picker.dart
@@ -77,12 +77,13 @@ class _ScrollPickerState extends State<ScrollPicker> {
                   }
 
                   var value = widget.values[index];
+                  var item = widget.items[index];    
 
                   final TextStyle? itemStyle =
                       (value == selectedValue) ? selectedStyle : defaultStyle;
 
                   return Center(
-                    child: Text(value, style: itemStyle),
+                    child: Text(item, style: itemStyle),
                   );
                 }),
                 controller: scrollController,


### PR DESCRIPTION
Scroll Picker was displaying and returning from the values list, this now displays the corresponding item in the scroll picker whilst still returning the value.