### PR TITLE
Fixing transformer not being called on scroll picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Releases
 
+## [3.1.1] - 2021-08-04
+
+- Fixing `transformer` method not being called on `showMaterialScrollPicker`
+
 ## [3.1.0] - 2021-06-11
 
 - provided a standard `PickerModel` that can be used with all picker type controls

--- a/lib/pickers/scroll_picker.dart
+++ b/lib/pickers/scroll_picker.dart
@@ -82,7 +82,7 @@ class _ScrollPickerState<T> extends State<ScrollPicker<T>> {
                   final TextStyle? itemStyle = (value == selectedValue) ? selectedStyle : defaultStyle;
 
                   return Center(
-                    child: Text('$value', style: itemStyle),
+                    child: Text(widget.transformer?.call(value) ?? '$value', style: itemStyle),
                   );
                 }),
                 controller: scrollController,
@@ -127,3 +127,4 @@ class _ScrollPickerState<T> extends State<ScrollPicker<T>> {
     }
   }
 }
+


### PR DESCRIPTION
Fixing issue #33. The transformer parameter wasn't being called on `scroll_picker.dart`.